### PR TITLE
Update to Jenkins 1.580.3 baseline and the new Parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,7 @@
         <developer>
             <id>oleg_nenashev</id>
             <name>Oleg Nenashev</name>
-            <email>nenashev@synopsys.com; o.v.nenashev@gmail.com</email>
-            <organizationUrl>http://www.synopsys.com</organizationUrl>
-            <organization>Synopsys Inc.</organization>              			
+            <email>o.v.nenashev@gmail.com</email>
             <roles>
                 <role>maintainer</role>
             </roles>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.509.3</version>
+        <version>2.12</version>
     </parent>
 
     <groupId>com.synopsys.arc.jenkinsci.plugins</groupId>
@@ -15,6 +15,8 @@
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Job+Restrictions+Plugin</url>
 
     <properties>
+        <jenkins.version>1.580.3</jenkins.version>
+        <java.level>6</java.level>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/JobCauseRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/JobCauseRestriction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2013-2016 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +31,7 @@ import hudson.model.Descriptor;
 /**
  * Restricts the job execution according to the build cause.
  * @param <TCause> A cause type to be checked
- * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * @author Oleg Nenashev
  */
 public abstract class JobCauseRestriction<TCause extends Cause>  
     implements Describable<JobCauseRestriction<? extends Cause>>  {

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/JobRestrictionProperty.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/JobRestrictionProperty.java
@@ -24,6 +24,7 @@
 package com.synopsys.arc.jenkinsci.plugins.jobrestrictions.jobs;
 
 import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.Messages;
+import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.restrictions.JobRestriction;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.model.AbstractBuild;
@@ -32,6 +33,7 @@ import hudson.model.Cause;
 import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
+import hudson.slaves.NodeProperty;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/JobRestrictionProperty.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/JobRestrictionProperty.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2013-2016 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,7 +36,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * A {@link NodeProperty}, which manages {@link JobRestriction}s for {@link AbstractBuild}s.
- * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * @author Oleg Nenashev
  */
 public class JobRestrictionProperty extends JobProperty {
     

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/JobRestrictionPropertyConfig.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/JobRestrictionPropertyConfig.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2013-2016 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +34,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * Stores the configuration for {@link JobRestrictionProperty}.
- * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * @author Oleg Nenashev
  */
 public class JobRestrictionPropertyConfig implements Describable<JobRestrictionPropertyConfig> {
     UpstreamCauseRestriction upstreamCauseRestriction;

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/UpstreamCauseRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/UpstreamCauseRestriction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2013-2016 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +34,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * Allows to restrict execution according to upstream cause.
- * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * @author Oleg Nenashev
  */
 public class UpstreamCauseRestriction extends JobCauseRestriction<Cause.UpstreamCause> {
 

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/UserIdCauseRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/UserIdCauseRestriction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2013-2016 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +31,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * Allows to restrict execution of job for {@link Cause.UserIdCause}.
- * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * @author Oleg Nenashev
  * @since 0.2
  */
 public class UserIdCauseRestriction extends JobCauseRestriction<Cause.UserIdCause>  {

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/nodes/JobRestrictionProperty.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/nodes/JobRestrictionProperty.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2013-2016 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,7 +36,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * A {@link NodeProperty}, which manages {@link JobRestriction}s for {@link Node}s.
- * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * @author Oleg Nenashev
  */
 public class JobRestrictionProperty extends NodeProperty<Node> {
 

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/JobRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/JobRestriction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Synopsys Inc., Oleg Nenashev <nenashev@synopsys.com> 
+ * Copyright 2013-2016 Synopsys Inc., Oleg Nenashev
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,7 +40,7 @@ import jenkins.model.Jenkins;
 /**
  * The extension point, which allows to restrict job executions.
  * 
- * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * @author Oleg Nenashev
  */
 public abstract class JobRestriction implements ExtensionPoint, Describable<JobRestriction>, Serializable {
     

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/JobRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/JobRestriction.java
@@ -24,6 +24,7 @@
 package com.synopsys.arc.jenkinsci.plugins.jobrestrictions.restrictions;
 
 import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.restrictions.logic.AnyJobRestriction;
+import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.util.JenkinsHelper;
 import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.Describable;
@@ -65,7 +66,7 @@ public abstract class JobRestriction implements ExtensionPoint, Describable<JobR
 
     @Override
     public JobRestrictionDescriptor getDescriptor() {
-        return (JobRestrictionDescriptor) Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (JobRestrictionDescriptor) JenkinsHelper.getInstanceOrDie().getDescriptorOrDie(getClass());
     }
 
     /**
@@ -73,7 +74,7 @@ public abstract class JobRestriction implements ExtensionPoint, Describable<JobR
      * @return List of {@link JobRestriction}s.
      */    
     public static DescriptorExtensionList<JobRestriction,JobRestrictionDescriptor> all() {
-        return Jenkins.getInstance().<JobRestriction,JobRestrictionDescriptor>getDescriptorList
+        return JenkinsHelper.getInstanceOrDie().<JobRestriction,JobRestrictionDescriptor>getDescriptorList
             (JobRestriction.class);
     }
     

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/JobRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/JobRestriction.java
@@ -28,14 +28,13 @@ import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.util.JenkinsHelper;
 import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.Describable;
-import hudson.model.Descriptor;
+import hudson.model.Job;
 import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.Run;
 import java.io.Serializable;
 import java.util.List;
 import javax.annotation.Nonnull;
-import jenkins.model.Jenkins;
 
 /**
  * The extension point, which allows to restrict job executions.

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/JobRestrictionBlockageCause.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/JobRestrictionBlockageCause.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2013-2016 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,7 +27,7 @@ import hudson.model.queue.CauseOfBlockage;
 
 /**
  * A specific blockage cause for {@link JobRestriction}s.
- * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * @author Oleg Nenashev
  */
 public class JobRestrictionBlockageCause extends CauseOfBlockage {
 

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/JobRestrictionDescriptor.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/JobRestrictionDescriptor.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2013-2016 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +28,7 @@ import hudson.model.Descriptor;
 
 /**
  * Descriptor class for {@link JobRestriction}s.
- * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * @author Oleg Nenashev
  */
 public abstract class JobRestrictionDescriptor extends Descriptor<JobRestriction> {
     public JobRestrictionDescriptor getDefaultSettingsProvider() {

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/AbstractUserCauseRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/AbstractUserCauseRestriction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2015 Oleg Nenashev <o.v.nenashev@gmail.com>.
+ * Copyright 2015-2016 Christopher Suarez, Oleg Nenashev
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,7 +38,7 @@ import javax.annotation.Nonnull;
 /**
  * Abstract class, which defines the logic of UserCause-based restrictions.
  * @author Christopher Suarez
- * @author Oleg Nenashev <o.v.nenashev@gmail.com>
+ * @author Oleg Nenashev
  * @since 0.4
  * @see StartedByUserRestriction
  * @see StartedByMemberOfGroupRestriction

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/RegexNameRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/RegexNameRestriction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2013-2016 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,7 +38,7 @@ import org.kohsuke.stapler.QueryParameter;
 
 /**
  * Restricts the jobs execution by applying regular expressions to their names.
- * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * @author Oleg Nenashev
  */
 public class RegexNameRestriction extends JobRestriction {
     String regexExpression;

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/StartedByMemberOfGroupRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/StartedByMemberOfGroupRestriction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2014-2015 Christopher Suarez, Oleg Nenashev
+ * Copyright 2014-2016 Christopher Suarez, Oleg Nenashev
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -55,7 +55,7 @@ import org.springframework.dao.DataAccessException;
  * In several cases the extension may load user data from {@link SecurityRealm},
  * so there can be significant delays in Jenkins {@link Queue}.
  * @author Christopher Suarez
- * @author Oleg Nenashev <o.v.nenashev@gmail.com>
+ * @author Oleg Nenashev
  * @since 0.4
  * @see StartedByUserRestriction
  */

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/StartedByMemberOfGroupRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/StartedByMemberOfGroupRestriction.java
@@ -45,6 +45,7 @@ import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.Messages;
 import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.restrictions.JobRestriction;
 import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.restrictions.JobRestrictionDescriptor;
 import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.util.GroupSelector;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Queue;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.springframework.dao.DataAccessException;
@@ -58,6 +59,9 @@ import org.springframework.dao.DataAccessException;
  * @since 0.4
  * @see StartedByUserRestriction
  */
+// TODO: it's a real issue, needs some love
+@SuppressFBWarnings(value = "SE_NO_SERIALVERSIONID", 
+        justification = "XStream does actually need serialization, the code needs refactoring in 1.0")
 public class StartedByMemberOfGroupRestriction extends AbstractUserCauseRestriction {
 
     private final List<GroupSelector> groupList;

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/StartedByUserRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/StartedByUserRestriction.java
@@ -27,6 +27,7 @@ package com.synopsys.arc.jenkinsci.plugins.jobrestrictions.restrictions.job;
 import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.Messages;
 import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.restrictions.JobRestrictionDescriptor;
 import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.util.UserSelector;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import java.util.HashSet;
 import java.util.List;
@@ -40,6 +41,9 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * @author Oleg Nenashev <o.v.nenashev@gmail.com>
  * @since 0.4
  */
+// TODO: it's a real issue, needs some love
+@SuppressFBWarnings(value = "SE_NO_SERIALVERSIONID", 
+        justification = "XStream does actually need serialization, the code needs refactoring in 1.0")
 public class StartedByUserRestriction extends AbstractUserCauseRestriction {
     
     private final List<UserSelector> usersList; 

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/StartedByUserRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/StartedByUserRestriction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2014 Oleg Nenashev <o.v.nenashev@gmail.com>.
+ * Copyright 2014-2016 Oleg Nenashev
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,7 +38,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * Handles restrictions from User causes.
- * @author Oleg Nenashev <o.v.nenashev@gmail.com>
+ * @author Oleg Nenashev
  * @since 0.4
  */
 // TODO: it's a real issue, needs some love

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/AbstractLogicExpression.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/AbstractLogicExpression.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2013-2016 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +31,7 @@ import hudson.model.Run;
  * Provides logic wrapper for all expressions, 
  * which don't utilize contents of RunnableItems.
  * @deprecated In the current state, this class is just a stub for future.
- * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * @author Oleg Nenashev
  */
 abstract class AbstractLogicExpression extends JobRestriction {
 

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/AndJobRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/AndJobRestriction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2013-2016 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +34,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * Virtual job restriction, which allows to check two restrictions at once.
- * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * @author Oleg Nenashev
+ * @see MultipleAndJobRestriction
  */
 public class AndJobRestriction extends JobRestriction {
 

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/AnyJobRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/AnyJobRestriction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2013-2016 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -33,7 +33,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * Takes any job.
- * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * @author Oleg Nenashev
  */
 public class AnyJobRestriction extends JobRestriction {
     @DataBoundConstructor

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/MultipleAndJobRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/MultipleAndJobRestriction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2013-2016 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +34,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * Implements "And" condition with multiple entries.
- * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * @author Oleg Nenashev
  * @since 0.2
  */
 public class MultipleAndJobRestriction extends JobRestriction {

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/MultipleOrJobRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/MultipleOrJobRestriction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2013-2016 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +34,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * Implements "Or" condition with multiple entries.
- * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * @author Oleg Nenashev
  * @since 0.2
  */
 public class MultipleOrJobRestriction extends JobRestriction {

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/NotJobRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/NotJobRestriction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2013-2016 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -33,8 +33,8 @@ import hudson.model.Run;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
- *
- * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Logic inversion condition.
+ * @author Oleg Nenashev
  */
 public class NotJobRestriction extends JobRestriction {
     JobRestriction restriction;

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/OrJobRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/OrJobRestriction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2013-2016 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -33,8 +33,9 @@ import hudson.model.Run;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
- *
- * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * OR condition, which takes two parameters
+ * @author Oleg Nenashev
+ * @see MultipleOrJobRestriction
  */
 public class OrJobRestriction extends JobRestriction {
     JobRestriction first;

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/GroupSelector.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/GroupSelector.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2014 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2014 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/GroupSelector.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/GroupSelector.java
@@ -28,7 +28,6 @@ import hudson.Functions;
 import hudson.Util;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
-import hudson.model.User;
 import hudson.security.SecurityRealm;
 import hudson.security.GroupDetails;
 import hudson.security.UserMayOrMayNotExistException;
@@ -39,8 +38,6 @@ import java.io.Serializable;
 
 import javax.annotation.CheckForNull;
 
-import jenkins.model.Jenkins;
-
 import org.acegisecurity.AuthenticationException;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -48,7 +45,7 @@ import org.kohsuke.stapler.QueryParameter;
 import org.springframework.dao.DataAccessException;
 
 /**
- * Describable Item, which allows to configure a user.
+ * Describable Item, which allows to configure a group.
  * @since 0.4
  */
 //TODO: Autocompletion

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/GroupSelector.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/GroupSelector.java
@@ -99,7 +99,7 @@ public class GroupSelector implements Describable<GroupSelector>, Serializable {
         
         public FormValidation doCheckSelectedGroupId(@QueryParameter String selectedGroupId) {
             selectedGroupId = Util.fixEmptyAndTrim(selectedGroupId);
-            SecurityRealm sr = Jenkins.getInstance().getSecurityRealm();
+            SecurityRealm sr = JenkinsHelper.getInstanceOrDie().getSecurityRealm();
             String eSelectedGroupId = Functions.escape(selectedGroupId);
             if (selectedGroupId == null) {
                 return FormValidation.error("Field is empty");

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/JenkinsHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/JenkinsHelper.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Oleg Nenashev.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.synopsys.arc.jenkinsci.plugins.jobrestrictions.util;
+
+import javax.annotation.Nonnull;
+import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Helper class for retrieving Jenkins instances.
+ * @author Oleg Nenashev
+ */
+@Restricted(NoExternalUse.class)
+public class JenkinsHelper {
+    
+    /**
+     * Gets the {@link Jenkins} singleton.
+     * @return {@link Jenkins} instance
+     * @throws IllegalStateException {@link Jenkins} has not been started, or was already shut down
+     */
+    @Nonnull
+    public static Jenkins getInstanceOrDie() throws IllegalStateException {
+        final Jenkins instance = Jenkins.getInstance();
+        if (instance == null) {
+            throw new IllegalStateException("Jenkins has not been started, or was already shut down");
+        }
+        return instance;
+    }
+    
+}

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/QueueHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/QueueHelper.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2013 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +28,7 @@ import hudson.model.Queue;
 
 /**
  * Provides additional for Queue objects.
- * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * @author Oleg Nenashev
  */
 public class QueueHelper {
     /**

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/QueueHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/QueueHelper.java
@@ -24,20 +24,29 @@
 package com.synopsys.arc.jenkinsci.plugins.jobrestrictions.util;
 
 import hudson.model.Item;
+import hudson.model.Job;
 import hudson.model.Queue;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.annotation.Nonnull;
 
 /**
  * Provides additional for Queue objects.
  * @author Oleg Nenashev
  */
+@Restricted(NoExternalUse.class)
 public class QueueHelper {
+
+    //TODO: Optimize by StringBuilder
     /**
      * Generates job-style project name for the buildable item
      * @deprecated Just a hack, will be removed in the future versions
-     * @param item
-     * @return String in the Job::getFullName() format (a/b/c/d)
+     * @param item Item, for which the name should be retrieved
+     * @return String in the {@link Job#getFullName()} format (a/b/c/d)
      */
-    public static String getFullName(Queue.BuildableItem item) {
+    @Deprecated
+    public static String getFullName(@Nonnull Queue.BuildableItem item) {
         Queue.Task current = item.task;
         String res = current.getName();
         //Fetching the full path of the item

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/UserSelector.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/UserSelector.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2014 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * Copyright 2014 Oleg Nenashev, Synopsys Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/JobRestrictionProperty/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/JobRestrictionProperty/config.jelly
@@ -1,7 +1,7 @@
 <!--
  * The MIT License
  *
- * Copyright 2013 Synopsys Inc., Oleg Nenashev <nenashev@synopsys.com>
+ * Copyright 2013-2016 Synopsys Inc., Oleg Nenashev
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/JobRestrictionPropertyConfig/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/JobRestrictionPropertyConfig/config.jelly
@@ -1,7 +1,7 @@
 <!--
  * The MIT License
  *
- * Copyright 2013 Synopsys Inc., Oleg Nenashev <nenashev@synopsys.com>
+ * Copyright 2013-2016 Synopsys Inc., Oleg Nenashev
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/UpstreamCauseRestriction/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/UpstreamCauseRestriction/config.jelly
@@ -1,7 +1,7 @@
 <!--
  * The MIT License
  *
- * Copyright 2013 Synopsys Inc., Oleg Nenashev <nenashev@synopsys.com>
+ * Copyright 2013-2016 Synopsys Inc., Oleg Nenashev
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/UserIdCauseRestriction/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/UserIdCauseRestriction/config.jelly
@@ -1,7 +1,7 @@
 <!--
  * The MIT License
  *
- * Copyright 2013 Synopsys Inc., Oleg Nenashev <nenashev@synopsys.com>
+ * Copyright 2013-2016 Synopsys Inc., Oleg Nenashev
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/nodes/JobRestrictionProperty/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/nodes/JobRestrictionProperty/config.jelly
@@ -1,7 +1,7 @@
 <!--
  * The MIT License
  *
- * Copyright 2013 Synopsys Inc., Oleg Nenashev <nenashev@synopsys.com>
+ * Copyright 2013-2016 Synopsys Inc., Oleg Nenashev
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/RegexNameRestriction/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/RegexNameRestriction/config.jelly
@@ -1,7 +1,7 @@
 <!--
  * The MIT License
  *
- * Copyright 2013 Synopsys Inc., Oleg Nenashev <nenashev@synopsys.com>
+ * Copyright 2013-2016 Synopsys Inc., Oleg Nenashev
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/StartedByMemberOfGroupRestriction/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/StartedByMemberOfGroupRestriction/config.jelly
@@ -1,7 +1,7 @@
 <!--
  * The MIT License
  *
- * Copyright 2014-2015 Christopher Suarez
+ * Copyright 2014-2016 Christopher Suarez
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/StartedByUserRestriction/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/StartedByUserRestriction/config.jelly
@@ -1,7 +1,7 @@
 <!--
  * The MIT License
  *
- * Copyright 2013 Synopsys Inc., Oleg Nenashev <nenashev@synopsys.com>
+ * Copyright 2013-2016 Synopsys Inc., Oleg Nenashev
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/AndJobRestriction/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/AndJobRestriction/config.jelly
@@ -1,7 +1,7 @@
 <!--
  * The MIT License
  *
- * Copyright 2013 Synopsys Inc., Oleg Nenashev <nenashev@synopsys.com>
+ * Copyright 2013-2016 Synopsys Inc., Oleg Nenashev
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/AnyJobRestriction/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/AnyJobRestriction/config.jelly
@@ -1,7 +1,7 @@
 <!--
  * The MIT License
  *
- * Copyright 2013 Synopsys Inc., Oleg Nenashev <nenashev@synopsys.com>
+ * Copyright 2013-2016 Synopsys Inc., Oleg Nenashev
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/MultipleAndJobRestriction/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/MultipleAndJobRestriction/config.jelly
@@ -3,7 +3,7 @@
 <!--
   ~ The MIT License
   ~
-  ~ Copyright (C) 2013 Synopsys Inc., Oleg Nenashev <nenashev@synopsys.com>
+  ~ Copyright (C) 2013-2016 Synopsys Inc., Oleg Nenashev
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/MultipleOrJobRestriction/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/MultipleOrJobRestriction/config.jelly
@@ -3,7 +3,7 @@
 <!--
   ~ The MIT License
   ~
-  ~ Copyright (C) 2013 Synopsys Inc., Oleg Nenashev <nenashev@synopsys.com>
+  ~ Copyright (C) 2013-2016 Synopsys Inc., Oleg Nenashev
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/NotJobRestriction/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/NotJobRestriction/config.jelly
@@ -1,7 +1,7 @@
 <!--
  * The MIT License
  *
- * Copyright 2013 Synopsys Inc., Oleg Nenashev <nenashev@synopsys.com>
+ * Copyright 2013-2016 Synopsys Inc., Oleg Nenashev
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/OrJobRestriction/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/logic/OrJobRestriction/config.jelly
@@ -1,7 +1,7 @@
 <!--
  * The MIT License
  *
- * Copyright 2013 Synopsys Inc., Oleg Nenashev <nenashev@synopsys.com>
+ * Copyright 2013-2016 Synopsys Inc., Oleg Nenashev
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/GroupSelector/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/GroupSelector/config.jelly
@@ -1,7 +1,7 @@
 <!--
  * The MIT License
  *
- * Copyright 2013 Synopsys Inc., Oleg Nenashev <nenashev@synopsys.com>
+ * Copyright 2013-2016 Synopsys Inc., Oleg Nenashev
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/UserSelector/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/UserSelector/config.jelly
@@ -1,7 +1,7 @@
 <!--
  * The MIT License
  *
- * Copyright 2013 Synopsys Inc., Oleg Nenashev <nenashev@synopsys.com>
+ * Copyright 2013-2016 Synopsys Inc., Oleg Nenashev
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   This plugin provides additional options, which allow to restrict execution of jobs
 </div>


### PR DESCRIPTION
Just a common parent POM update.
Bumped to 1.580.3, because Pipeline support is on my plate.

CC @reviewbybees @alexsomai