### PR TITLE
[JENKINS-36626] - Get full names for queue items when they're available

### DIFF
--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/QueueHelper.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/QueueHelper.java
@@ -23,13 +23,13 @@
  */
 package com.synopsys.arc.jenkinsci.plugins.jobrestrictions.util;
 
+import javax.annotation.Nonnull;
+
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Queue;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
-
-import javax.annotation.Nonnull;
 
 /**
  * Provides additional for Queue objects.
@@ -48,22 +48,26 @@ public class QueueHelper {
     @Deprecated
     public static String getFullName(@Nonnull Queue.BuildableItem item) {
         Queue.Task current = item.task;
-        String res = current.getName();
-        //Fetching the full path of the item
-        if (current instanceof Item) {
-            Item stub = (Item)current;
-            return stub.getFullName();
-        }
-        
-        // Default approach via interface
-        while (true) {
+        String res = getItemName(current);
+
+        // this is only executed if we didn't call Item.getFullName() in getItemName
+        while (!(current instanceof Item)) {
             Queue.Task parent = current.getOwnerTask();
             if (parent == current || parent == null) {
                 break;
-            }          
-            res = parent.getName() + "/" + res;
+            }
+            res = getItemName(parent) + "/" + res;
             current = parent;
-        }        
+        }
         return res;
+    }
+
+    private static String getItemName(Queue.Task task) {
+        if (task instanceof Item) {
+            Item stub = (Item)task;
+            return stub.getFullName();
+        } else {
+            return task.getName();
+        }
     }
 }


### PR DESCRIPTION
This fixes a problem that occurs when a pipeline (workflow) job is inside a folder and a regex matching the folder's name is used as an execution restriction. In these instances, `QueueHelper` appends only the job name to the start of the `Queue.Task`'s name instead of the appending the full name.

For example, assume this structure exists:

    Test-Folder (folder)
        - FreeStyleJob (freestyle job)
        - PipelineJob (pipeline/workflow job)

And an agent exists with Job Name Regex restriction set to

    Test-Folder/.*

When `FreeStyleJob` runs, QueueHelper returns its name as `Test-Folder/FreeStyleJob` which matches the agent's regex is is allowed to execute.

When `PipelineJob` runs, `QueueHelper` returns the step names as `PipelineJob/part of Test-Folder » PipelineJob #1` which does not match the regex so the job does not execute.

This change allows `QueueHelper` to determine if the `Queue.Task`'s parent implements `Item` and, if it does, take advantage of `Item.getFullName()`. In the example above, the name will now be returned as `Test-Folder/PipelineJob/part of Test-Folder » PipelineJob #1`