### PR TITLE
[JENKINS-34377] - AbstractUserCauseRestriction now correctly retrieves causes for Pipeline's PlaceHolder tasks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Job+Restrictions+Plugin</url>
 
     <properties>
-        <jenkins.version>1.609.3</jenkins.version>
-        <java.level>6</java.level>
+        <jenkins.version>2.60.3</jenkins.version>
+        <java.level>8</java.level>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -63,6 +63,11 @@
     
     <dependencies>
         <dependency>
+        	<groupId>org.jenkins-ci.plugins.workflow</groupId>
+        	<artifactId>workflow-durable-task-step</artifactId>
+        	<version>2.10</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
             <version>1.7.1</version>
@@ -73,6 +78,30 @@
             <artifactId>matrix-auth</artifactId>
             <version>1.4</version>
             <scope>test</scope>
+        </dependency>
+         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>junit</artifactId>
+            <version>1.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+        	<groupId>org.jenkins-ci.plugins.workflow</groupId>
+        	<artifactId>workflow-aggregator</artifactId>
+        	<version>2.4</version>
+        	<scope>test</scope>
+        </dependency>
+        <dependency>
+        	<groupId>org.jenkins-ci.plugins</groupId>
+        	<artifactId>credentials</artifactId>
+        	<version>2.0.4</version>
+        	<scope>test</scope>
+        </dependency>
+        <dependency>
+        	<groupId>org.jenkins-ci.plugins</groupId>
+        	<artifactId>scm-api</artifactId>
+        	<version>1.3</version>
+        	<scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Job+Restrictions+Plugin</url>
 
     <properties>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>1.651.3</jenkins.version>
         <java.level>8</java.level>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/AbstractUserCauseRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/AbstractUserCauseRestriction.java
@@ -119,27 +119,27 @@ public abstract class AbstractUserCauseRestriction extends JobRestriction {
         
         // The enclosed BuildableItem has a Pipeline step task
         if (item.task.getClass().equals(PlaceholderTask.class)) {
-        	// This tasks's context is present, causes can be retrieved
-        	if (((PlaceholderTask) item.task).run() != null) {
-        		causes = ((PlaceholderTask) item.task).run().getCauses();
-        	// This task's context has not loaded yet, mostly likely due to a Jenkins' restart
-        	} else {
-        		// Context loaded and is now present
-        		if (((PlaceholderTask) item.task).runForDisplay() != null) {
-        			causes = ((PlaceholderTask) item.task).runForDisplay().getCauses();
-        		// Context cannot be loaded
-        		} else {
-        			causes = null;
-        		}
-        	}
+            // This tasks's context is present, causes can be retrieved
+            if (((PlaceholderTask) item.task).run() != null) {
+                causes = ((PlaceholderTask) item.task).run().getCauses();
+            // This task's context has not loaded yet, mostly likely due to a Jenkins' restart
+            } else {
+                // Context loaded and is now present
+                if (((PlaceholderTask) item.task).runForDisplay() != null) {
+                    causes = ((PlaceholderTask) item.task).runForDisplay().getCauses();
+                // Context cannot be loaded
+                } else {
+                    causes = null;
+                }
+            }
         } else {
-        	causes = new ArrayList<Cause>();
-	        for (Action action : item.getAllActions()) {
-	            if (action instanceof CauseAction) {
-	                CauseAction causeAction = (CauseAction) action;
-	                causes.addAll(causeAction.getCauses());
-	            } 
-	        }
+            causes = new ArrayList<Cause>();
+            for (Action action : item.getAllActions()) {
+                if (action instanceof CauseAction) {
+                    CauseAction causeAction = (CauseAction) action;
+                    causes.addAll(causeAction.getCauses());
+                } 
+            }
         }
         return canTake(causes);
     }

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/AbstractUserCauseRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/AbstractUserCauseRestriction.java
@@ -120,20 +120,25 @@ public abstract class AbstractUserCauseRestriction extends JobRestriction {
     @Override
     public boolean canTake(Queue.BuildableItem item) {
         final List<Cause> causes;
+        List<Cause> causes_placeholdertask = null;
         
         // The enclosed BuildableItem has a Pipeline step task
         if (item.task instanceof PlaceholderTask) {
             // This tasks's context is present, causes can be retrieved
             if (((PlaceholderTask) item.task).run() != null) {
-                causes = ((PlaceholderTask) item.task).run().getCauses();
+                causes_placeholdertask = ((PlaceholderTask) item.task).run().getCauses();
             // This task's context has not loaded yet, mostly likely due to a Jenkins' restart
             // Context loaded via runForDisplay() and is now present
             } else if (((PlaceholderTask) item.task).runForDisplay() != null) {
-            	causes = ((PlaceholderTask) item.task).runForDisplay().getCauses();
-            // Context cannot be loaded
+            	causes_placeholdertask = ((PlaceholderTask) item.task).runForDisplay().getCauses();
+            }
+            
+            if (causes_placeholdertask != null) {
+            	causes = causes_placeholdertask;
+            // Causes could not be loaded
             } else {
             	causes = new ArrayList<Cause>();
-            	LOGGER.severe(MessageFormat.format("PlaceholderTask {0} from plugin {1} could not have its context loaded. Causes cannot be retrieved.",
+            	LOGGER.severe(MessageFormat.format("PlaceholderTask {0} from plugin {1} could not have its causes retrieved.",
             		item.task.getDisplayName(), "workflow-durable-task-step"));
             }
         } else {

--- a/src/test/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/UserIdCauseRestrictionTest.java
+++ b/src/test/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/UserIdCauseRestrictionTest.java
@@ -63,13 +63,13 @@ public class UserIdCauseRestrictionTest {
     
     // ACL.impersonate() deprecated. Replaced with ACL.as().
     private FreeStyleBuild runAsUser(final FreeStyleProject project, String username, final boolean legacyCause) 
-    		throws InterruptedException, ExecutionException, TimeoutException {
-    	User user = j.jenkins.getUser(username);
-    	final List<QueueTaskFuture<FreeStyleBuild>> scheduled = new ArrayList<QueueTaskFuture<FreeStyleBuild>>(1);
-    	try (ACLContext ctx = ACL.as(user)) {
-    		final Cause cause = legacyCause ? new Cause.UserCause() : new Cause.UserIdCause();
-    		scheduled.add(project.scheduleBuild2(0, cause));
-    	}
+            throws InterruptedException, ExecutionException, TimeoutException {
+        User user = j.jenkins.getUser(username);
+        final List<QueueTaskFuture<FreeStyleBuild>> scheduled = new ArrayList<QueueTaskFuture<FreeStyleBuild>>(1);
+        try (ACLContext ctx = ACL.as(user)) {
+            final Cause cause = legacyCause ? new Cause.UserCause() : new Cause.UserIdCause();
+            scheduled.add(project.scheduleBuild2(0, cause));
+        }
 
         Assert.assertThat(scheduled, not(nullValue()));
         return scheduled.get(0).get(1, TimeUnit.MINUTES);

--- a/src/test/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/UserIdCauseRestrictionTest.java
+++ b/src/test/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/UserIdCauseRestrictionTest.java
@@ -3,7 +3,6 @@ package com.synopsys.arc.jenkinsci.plugins.jobrestrictions.jobs;
 import hudson.model.*;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.security.ACL;
-import hudson.security.ACLContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -61,16 +60,18 @@ public class UserIdCauseRestrictionTest {
         assertThat("Job restriction should have prohibited the manual launch for the Legacy UserCause", build.getResult(), equalTo(Result.FAILURE));
     }
     
-    // ACL.impersonate() deprecated. Replaced with ACL.as().
     private FreeStyleBuild runAsUser(final FreeStyleProject project, String username, final boolean legacyCause) 
             throws InterruptedException, ExecutionException, TimeoutException {
         User user = j.jenkins.getUser(username);
         final List<QueueTaskFuture<FreeStyleBuild>> scheduled = new ArrayList<QueueTaskFuture<FreeStyleBuild>>(1);
-        try (ACLContext ctx = ACL.as(user)) {
-            final Cause cause = legacyCause ? new Cause.UserCause() : new Cause.UserIdCause();
-            scheduled.add(project.scheduleBuild2(0, cause));
-        }
-
+        ACL.impersonate(user.impersonate(), new Runnable() {
+            @Override
+            public void run() {
+                final Cause cause = legacyCause ? new Cause.UserCause() : new Cause.UserIdCause();
+                scheduled.add(project.scheduleBuild2(0, cause));
+            }
+        });
+        
         Assert.assertThat(scheduled, not(nullValue()));
         return scheduled.get(0).get(1, TimeUnit.MINUTES);
     }

--- a/src/test/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/nodes/UserIDCauseRestrictionPipelineTest.java
+++ b/src/test/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/nodes/UserIDCauseRestrictionPipelineTest.java
@@ -1,14 +1,25 @@
 package com.synopsys.arc.jenkinsci.plugins.jobrestrictions.nodes;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import hudson.model.Queue;
+import hudson.model.queue.QueueTaskFuture;
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,9 +35,13 @@ import hudson.model.User;
 import hudson.security.ACL;
 import hudson.slaves.DumbSlave;
 
+import javax.annotation.Nonnull;
+
 public class UserIDCauseRestrictionPipelineTest {
   
-    @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
     private static final String TEST_USERNAME = "foo";
     private static final String TEST_USERNAME_2 = "bar";
   
@@ -45,25 +60,15 @@ public class UserIDCauseRestrictionPipelineTest {
         slave.getNodeProperties().add(new JobRestrictionProperty(new StartedByUserRestriction(listUserSelector, false, true, false)));
       
         // create pipeline job that will run on the test slave
-        WorkflowJob project = j.jenkins.createProject(WorkflowJob.class, "pipeline_demo");
+        final WorkflowJob project = j.jenkins.createProject(WorkflowJob.class, "pipeline_demo");
         project.setDefinition(new CpsFlowDefinition(
                 "node('" + slave.getNodeName() + "') {\n" +
                 "    sh('echo hello')\n" +
                 "}", true));
       
         // schedule a build for the pipeline job as the user who is accepted by the test slave
-        ACL.impersonate((User.getById(TEST_USERNAME, true)).impersonate(), new Runnable() {
-            @Override
-            public void run() {
-            	project.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause()));
-            }
-        });
-      
-        // more than enough time given for the build to finish
-        Thread.sleep(10000);
-      
-        WorkflowRun build = project.getFirstBuild();
-        assertThat("Job restriction should allow pipeline jobs", build.getResult(), equalTo(Result.SUCCESS));
+        WorkflowRun run = runAsUserAndWaitForCompletion(project, TEST_USERNAME);
+        assertThat("Job restriction should allow pipeline jobs", run.getResult(), equalTo(Result.SUCCESS));
     }
     
     @Test
@@ -75,25 +80,46 @@ public class UserIDCauseRestrictionPipelineTest {
         // add StartedByUser Restriction property to node
         slave.getNodeProperties().add(new JobRestrictionProperty(new StartedByUserRestriction(listUserSelector, false, true, false)));
       
-        WorkflowJob project = j.jenkins.createProject(WorkflowJob.class, "pipeline_demo");
+        final WorkflowJob project = j.jenkins.createProject(WorkflowJob.class, "pipeline_demo");
         project.setDefinition(new CpsFlowDefinition(
                 "node('" + slave.getNodeName() + "') {\n" +
                 "    sh('echo hello')\n" +
                 "}", true));
       
         // schedule a build for the pipeline job as the user who is not accepted by the test slave
-        ACL.impersonate((User.getById(TEST_USERNAME, true)).impersonate(), new Runnable() {
-            @Override
-            public void run() {
-            	project.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause()));
-            }
-        });
+        QueueTaskFuture<WorkflowRun> runFuture = runAsUser(project, TEST_USERNAME);
+        WorkflowRun run = runFuture.waitForStart();
+        Thread.sleep(2000); // Any way to do it better
+        List<StepExecution> executions = run.getExecutionPromise().get().getCurrentExecutions(true).get();
+        assertThat("Missing current head", executions.size(), equalTo(1));
+        StepExecution currentExecution = executions.get(0);
+        assertThat(currentExecution, instanceOf(ExecutorStepExecution.class));
+        ExecutorStepExecution exec = ((ExecutorStepExecution)currentExecution);
 
-        // more than enough time given for the build to finish
-        Thread.sleep(10000);
-      
-        // the return value of build.getResult() will be null
-        WorkflowRun build = project.getFirstBuild();
-        assertThat("Job restriction should allow pipeline jobs", build.getResult(), not(equalTo(Result.SUCCESS)));
+        // Now we know there is a waiting execution
+        List<Queue.BuildableItem> buildableItems = j.jenkins.getQueue().getBuildableItems();
+        assertThat("There is no buildable items in the queue. The job is not blocked", buildableItems.size(), equalTo(1));
+        assertThat(buildableItems.get(0).task, instanceOf(ExecutorStepExecution.PlaceholderTask.class));
+        assertThat("The task is not blocked", buildableItems.get(0).getCauseOfBlockage(), not(nullValue()));
+    }
+
+    @Nonnull
+    private QueueTaskFuture<WorkflowRun> runAsUser(WorkflowJob job, String username) throws InterruptedException, ExecutionException {
+        QueueTaskFuture<WorkflowRun> runFuture;
+        SecurityContext old = ACL.impersonate((User.getById(username, true)).impersonate());
+        try {
+            runFuture = job.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause()));
+        } finally {
+            SecurityContextHolder.setContext(old);
+        }
+        Assert.assertNotNull("The run has not been scheduled for the job " + job + " and user " + username, runFuture);
+        return runFuture;
+    }
+
+
+    @Nonnull
+    private WorkflowRun runAsUserAndWaitForCompletion(WorkflowJob job, String username) throws InterruptedException, ExecutionException {
+        // We have a test timeout, extra timeout is not needed
+        return runAsUser(job, username).get();
     }
 }

--- a/src/test/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/nodes/UserIDCauseRestrictionPipelineTest.java
+++ b/src/test/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/nodes/UserIDCauseRestrictionPipelineTest.java
@@ -22,7 +22,6 @@ import hudson.model.CauseAction;
 import hudson.model.Result;
 import hudson.model.User;
 import hudson.security.ACL;
-import hudson.security.ACLContext;
 import hudson.slaves.DumbSlave;
 
 public class UserIDCauseRestrictionPipelineTest {
@@ -53,9 +52,12 @@ public class UserIDCauseRestrictionPipelineTest {
                 "}", true));
       
         // schedule a build for the pipeline job as the user who is accepted by the test slave
-        try (ACLContext ctx = ACL.as(User.getById(TEST_USERNAME, true))) {
-            project.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause()));
-        }
+        ACL.impersonate((User.getById(TEST_USERNAME, true)).impersonate(), new Runnable() {
+            @Override
+            public void run() {
+            	project.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause()));
+            }
+        });
       
         // more than enough time given for the build to finish
         Thread.sleep(10000);
@@ -80,9 +82,12 @@ public class UserIDCauseRestrictionPipelineTest {
                 "}", true));
       
         // schedule a build for the pipeline job as the user who is not accepted by the test slave
-        try (ACLContext ctx = ACL.as(User.getById(TEST_USERNAME, true))) {
-            project.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause()));
-        }
+        ACL.impersonate((User.getById(TEST_USERNAME, true)).impersonate(), new Runnable() {
+            @Override
+            public void run() {
+            	project.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause()));
+            }
+        });
 
         // more than enough time given for the build to finish
         Thread.sleep(10000);

--- a/src/test/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/nodes/UserIDCauseRestrictionPipelineTest.java
+++ b/src/test/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/nodes/UserIDCauseRestrictionPipelineTest.java
@@ -1,0 +1,94 @@
+package com.synopsys.arc.jenkinsci.plugins.jobrestrictions.nodes;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.restrictions.job.StartedByUserRestriction;
+import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.util.UserSelector;
+import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.nodes.JobRestrictionProperty;
+
+import hudson.model.Cause;
+import hudson.model.CauseAction;
+import hudson.model.Result;
+import hudson.model.User;
+import hudson.security.ACL;
+import hudson.security.ACLContext;
+import hudson.slaves.DumbSlave;
+
+public class UserIDCauseRestrictionPipelineTest {
+	
+	@Rule public JenkinsRule j = new JenkinsRule();
+	private static final String TEST_USERNAME = "foo";
+	private static final String TEST_USERNAME_2 = "bar";
+	
+	@Before
+    public void setupSecurityRealm() {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+    }
+	
+    @Test
+    public void nodeShouldAllowPipelineRunsByAcceptedUser_UserIdCause() throws Exception {
+    	DumbSlave slave = j.createOnlineSlave();
+    	List<UserSelector> listUserSelector = new ArrayList<UserSelector>(1);
+    	listUserSelector.add(new UserSelector(TEST_USERNAME));
+    	
+    	// add StartedByUser Restriction property to node
+    	slave.getNodeProperties().add(new JobRestrictionProperty(new StartedByUserRestriction(listUserSelector, false, true, false)));
+    	
+    	// create pipeline job that will run on the test slave
+    	WorkflowJob project = j.jenkins.createProject(WorkflowJob.class, "pipeline_demo");
+    	project.setDefinition(new CpsFlowDefinition(
+    			"node('" + slave.getNodeName() + "') {\n" +
+                "    sh('echo hello')\n" +
+                "}", true));
+    	
+    	// schedule a build for the pipeline job as the user who is accepted by the test slave
+    	try (ACLContext ctx = ACL.as(User.getById(TEST_USERNAME, true))) {
+    		project.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause()));
+    	}
+    	
+    	// more than enough time given for the build to finish
+    	Thread.sleep(10000);
+    	
+    	WorkflowRun build = project.getFirstBuild();
+        assertThat("Job restriction should allow pipeline jobs", build.getResult(), equalTo(Result.SUCCESS));
+    }
+    
+    @Test
+    public void nodeShouldNotAllowPipelineRunsByUnacceptedUser_UserIdCause() throws Exception {
+    	DumbSlave slave = j.createOnlineSlave();
+    	List<UserSelector> listUserSelector = new ArrayList<UserSelector>(1);
+    	listUserSelector.add(new UserSelector(TEST_USERNAME_2));
+    	
+    	// add StartedByUser Restriction property to node
+    	slave.getNodeProperties().add(new JobRestrictionProperty(new StartedByUserRestriction(listUserSelector, false, true, false)));
+    	
+    	WorkflowJob project = j.jenkins.createProject(WorkflowJob.class, "pipeline_demo");
+    	project.setDefinition(new CpsFlowDefinition(
+                "node('" + slave.getNodeName() + "') {\n" +
+                "    sh('echo hello')\n" +
+                "}", true));
+    	
+    	// schedule a build for the pipeline job as the user who is not accepted by the test slave
+    	try (ACLContext ctx = ACL.as(User.getById(TEST_USERNAME, true))) {
+    		project.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause()));
+    	}
+
+    	// more than enough time given for the build to finish
+    	Thread.sleep(10000);
+    	
+    	// the return value of build.getResult() will be null
+    	WorkflowRun build = project.getFirstBuild();
+        assertThat("Job restriction should allow pipeline jobs", build.getResult(), not(equalTo(Result.SUCCESS)));
+    }
+}


### PR DESCRIPTION
This is an updated version of #16 by @msqb.
It keeps the same idea, but the implementation is more a bit more robust. 

Generally I think that the PlaceHolder task should have the `UpstreamCause` task pointing to the `WorkflowRun`. In such case this plugin will start working as well as other plugins depending on UpstreamCause resolution (e.g. https://github.com/search?p=1&q=org%3Ajenkinsci+getUpstreamCauses%28%29&type=Code)

CC @reviewbybees, especially @abayer and @svanoort 
