### PR TITLE
Jenkinsfile: Build on Linux only.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,2 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
-buildPlugin()
+buildPlugin(platforms: ['linux'])


### PR DESCRIPTION
Some tests require `sh` to be available. I will fix it later