### PR TITLE
[JENKINS-51359] Bugfix Job class restriction form validation

### DIFF
--- a/src/main/java/io/jenkins/plugins/jobrestrictions/util/ClassSelector.java
+++ b/src/main/java/io/jenkins/plugins/jobrestrictions/util/ClassSelector.java
@@ -30,6 +30,7 @@ import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import java.io.Serializable;
 import javax.annotation.CheckForNull;
+import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
@@ -90,7 +91,7 @@ public class ClassSelector implements Describable<ClassSelector>, Serializable {
             }
 
             try {
-                Class.forName(selectedClass);
+                Jenkins.getInstance().getPluginManager().uberClassLoader.loadClass(_selectedClass);
             } catch (Exception ex) {
                 return FormValidation.warning("Class " + _selectedClass + " cannot be resolved: " + ex.toString());
             }


### PR DESCRIPTION
By default, the class loader for plugins (i.e. `Class.forName(String name)`) only include classes in which the plugin directly depends.  Since this validation field is testing for any class in all of Jenkins, we should rely on the uber classloader provided by the plugin manager.

Originally reported in [JENKINS-51359][JENKINS-51359] but also reported as a comment in [JENKINS-31866][JENKINS-31866].  This should help resolve [JENKINS-51359][JENKINS-51359].

I manually tested this successfully.

See also:

- [JENKINS-31866][JENKINS-31866] Attempts to restrict Pipeline jobs from running on master result in job hanging
- [JENKINS-51359][JENKINS-51359] Unclear documentation class restriction validation claims classes that exist are not found

[JENKINS-31866]: https://issues.jenkins-ci.org/browse/JENKINS-31866
[JENKINS-51359]: https://issues.jenkins-ci.org/browse/JENKINS-51359