### PR TITLE
Move Changelog to GitHub Releases

### DIFF
--- a/docs/CHANGELOG.old.md
+++ b/docs/CHANGELOG.old.md
@@ -1,4 +1,8 @@
-# Version history
+# Version history (Archived)
+
+## Recent version
+
+See [GitHub Releases](https://github.com/jenkinsci/job-restrictions-plugin/releases)
 
 ## Version 0.8 (Oct 06, 2018)
 


### PR DESCRIPTION
This change will make GitHub Releases an official location for changelogs