### PR TITLE
Use https: for scm URL, not git:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     </developers>
 
     <scm>
-        <connection>scm:git:ssh://github.com/${gitHubRepo}.git</connection>
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/${gitHubRepo}.git</developerConnection>
         <url>https://github.com/${gitHubRepo}</url>
       <tag>${scmTag}</tag>


### PR DESCRIPTION
## Use https:// instead of git:// protocol for SCM URL

GitHub has deprecated the unencrypted git protocol.  Use https:// protocol instead for read access to the repository.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
