### PR TITLE
Use spotbugs CheckForNull, not JSR-305

### DIFF
--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/JobRestrictionProperty.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/jobs/JobRestrictionProperty.java
@@ -36,7 +36,7 @@ import hudson.model.JobPropertyDescriptor;
 import hudson.slaves.NodeProperty;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 /**
  * A {@link NodeProperty}, which manages {@link JobRestriction}s for {@link AbstractBuild}s.

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/AbstractUserCauseRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/AbstractUserCauseRestriction.java
@@ -32,7 +32,7 @@ import hudson.model.Queue;
 import hudson.model.Run;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/StartedByMemberOfGroupRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/StartedByMemberOfGroupRestriction.java
@@ -32,7 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import jenkins.model.Jenkins;

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/StartedByUserRestriction.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/restrictions/job/StartedByUserRestriction.java
@@ -32,7 +32,7 @@ import hudson.Extension;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.kohsuke.stapler.DataBoundConstructor;
 

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/GroupSelector.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/GroupSelector.java
@@ -37,7 +37,7 @@ import hudson.util.FormValidation.Kind;
 import java.io.Serializable;
 import java.util.Objects;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 import jenkins.model.Jenkins;
 import org.acegisecurity.AuthenticationException;

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/UserSelector.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/jobrestrictions/util/UserSelector.java
@@ -31,7 +31,7 @@ import hudson.model.User;
 import hudson.util.FormValidation;
 import java.io.Serializable;
 import java.util.Objects;
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;

--- a/src/main/java/io/jenkins/plugins/jobrestrictions/util/ClassSelector.java
+++ b/src/main/java/io/jenkins/plugins/jobrestrictions/util/ClassSelector.java
@@ -31,7 +31,7 @@ import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import java.io.Serializable;
 import java.util.Objects;
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;


### PR DESCRIPTION
## Use spotbugs `CheckForNull`, not JSR-305

https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/ explains that JSR-305 was never adopted, while spotbugs annotations are well maintained.

### Testing done

Compiled with the changes.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
